### PR TITLE
Fixed build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _*
 /src/_version.h
 /CMakeLists.txt.user
+/build
+/.vscode

--- a/src/config/ParseConfig.cpp
+++ b/src/config/ParseConfig.cpp
@@ -7,6 +7,7 @@
 #include <istream>
 #include <algorithm>
 #include <iterator>
+#include <sstream>
 
 namespace {
 


### PR DESCRIPTION
The project failed to build because of missing `<sstream>` reference. `auto ss = std::stringstream();` introduced in https://github.com/houmain/keymapper/commit/23ad2c7cf254604d145f1d04e777afd73c06f6b1 throwed 'stringstream is undefined' error.

Also added build artefacts to git ignore created during compilation using Microsoft's VS Build Tools in VSCode.
