### PR TITLE
Fixed terminal commands containing comment symbols

### DIFF
--- a/src/config/ParseKeySequence.cpp
+++ b/src/config/ParseKeySequence.cpp
@@ -168,6 +168,10 @@ void ParseKeySequence::parse(It it, const It end) {
       up_any_keys_not_up_yet();
       --in_modified_group;
     }
+    else if (skip(&it, end, "#") || skip(&it, end, ";")) {
+      flush_key_buffer(true);
+      break;
+    }
     else {
       if (!in_together_group ||
           it == end)

--- a/src/config/string_iteration.h
+++ b/src/config/string_iteration.h
@@ -37,7 +37,11 @@ bool skip_space(ForwardIt* it, ForwardIt end) {
 
 template<typename ForwardIt>
 bool skip_comments(ForwardIt* it, ForwardIt end) {
-  if (skip(it, end, "#") || skip(it, end, ";")) {
+  if (*it == end)
+    return false;
+
+  auto firstchar = static_cast<unsigned char>(**it);
+  if (firstchar == '#' || firstchar == ';') {
     skip_until(it, end, "\n");
     return true;
   }

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ostream>
+#include <sstream>
 #include "catch.hpp"
 #include "config/Key.h"
 


### PR DESCRIPTION
When a terminal command contains `#` or `;` it should not be treated as commend. Broken use case example:
```
A >> $(start powershell -NoExit -command "$Host.UI.RawUI.WindowTitle = 'PowerShell'; cd ~")
```
`;` here breaks the config.

To fix it I moved comment parsing logic to `ParseKeySequence.cpp`, so we are aware of a context where a comment is found. However, we should still trim macros before processing the sequence, since they cannot contain terminal commands (original behavior) and comments in modifier blocks are unacceptable. This does not break:
```
MyMacro = A B C# comment
A >> Shift{MyMacro}
```

All tests passed successfully. Needed to  do `#include <sstream>` fix in `test.h` too.