### PR TITLE
device filter matches a list of devices

### DIFF
--- a/src/runtime/Stage.h
+++ b/src/runtime/Stage.h
@@ -21,9 +21,7 @@ public:
     std::vector<KeySequence> outputs;
     std::vector<CommandOutput> command_outputs;
     std::string device_filter;
-
-    // negative means any device
-    int device_index{ -1 };
+    std::vector<int> device_indces;
   };
 
   explicit Stage(std::vector<Context> contexts);


### PR DESCRIPTION
My 2 devices show up as multiple event devices.
```
Grabbing device event3 'Razer Razer Naga 2014'
Grabbing device event7 'Razer Razer BlackWidow Ultimate 2013'
Grabbing device event8 'Razer Razer BlackWidow Ultimate 2013'
Grabbing device event9 'Razer Razer BlackWidow Ultimate 2013'
Grabbing device event13 'Razer Razer Naga 2014'
Grabbing device event18 'Razer Razer Naga 2014'
```
The currently implimentation maps to the first found device which may not have the keys I want to map, This PR will allow matching all devices that have the same name, effectively treating them as one device.

As per https://github.com/houmain/keymapper/pull/42 this may have the side effect of treating multiple physical devices as one device too. 