### PR TITLE
fix invalid index lookup on null objects

### DIFF
--- a/extra/share/kwin/scripts/keymapper/contents/code/main.js
+++ b/extra/share/kwin/scripts/keymapper/contents/code/main.js
@@ -14,7 +14,7 @@ connectWindowActivated(function(client){
         "/com/github/houmain/Keymapper",
         "com.github.houmain.Keymapper",
         "WindowFocus",
-        "caption" in client ? client.caption : "",
-        "resourceClass" in client ? client.resourceClass : ""
+        client?.caption ?? "",
+        client?.resourceClass ?? ""
     );
 });


### PR DESCRIPTION
I ran into an null reference index. Symptom was log spam and a no longer function keymapper (until I restarted it or my session). Here's some logs (the logs were added by me):


``` syslog
Sep 28 01:00:59 hostname kwin_x11[1033838]: js: null
Sep 28 01:00:58 hostname kwin_x11[1033838]: js: KWin::X11Window(0x5e805a503ea0)
Sep 28 01:00:58 hostname kwin_x11[1033838]: file:///usr/share/kwin/scripts/keymapper/contents/code/main.js:18: TypeError: Type error
Sep 28 01:00:58 hostname kwin_x11[1033838]: js: null
Sep 28 01:00:56 hostname kwin_x11[1033838]: js: KWin::X11Window(0x5e805afcd000)
Sep 28 01:00:56 hostname kwin_x11[1033838]: file:///usr/share/kwin/scripts/keymapper/contents/code/main.js:18: TypeError: Type error
Sep 28 01:00:56 hostname kwin_x11[1033838]: js: null
Sep 28 01:00:54 hostname kwin_x11[1033838]: js: KWin::X11Window(0x5e805a503ea0)
Sep 28 01:00:54 hostname kwin_x11[1033838]: file:///usr/share/kwin/scripts/keymapper/contents/code/main.js:18: TypeError: Type error
Sep 28 01:00:54 hostname kwin_x11[1033838]: js: null
```

Bug in action, from keypresses and probably more. For the fix,  went with somewhat modern js syntax (supported since 2020 by major vendors); let me know and I can do it with a more conservative, verbose solution. I dug for a bit but couldn't find any info on the js versions each KDE release supports.

The above fix was tested on KDE6, Arch. I double checked it wasn't a bug on them as well and found this for the `windowActivated` functions:

> windowActivated(KWin::EffectWindow *w): Signal emitted when a window gets activated. w The new active window, **or NULL** if there is no active window.


So whether old js style or modern it needed to be fixed.