### PR TITLE
Fix build on musl-based distros

### DIFF
--- a/src/common/Connection.cpp
+++ b/src/common/Connection.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <unistd.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 
 #endif // !defined(_WIN32)
 


### PR DESCRIPTION
Building on musl-based distros (tested on Void Linux x86_64-musl) resulted in a compilation error on `Connection.cpp` due to `timeval` being incomplete (missing a definition).

I fixed it by just adding an include for `<sys/time.h>`, and now the build succeeds.