### PR TITLE
Cursor visibility modifier on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,8 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(SOURCES_SERVER ${SOURCES_SERVER}
     src/server/windows/Devices.cpp
     src/server/windows/Devices.h
+    src/server/windows/HookThread.cpp
+    src/server/windows/HookThread.h
     src/server/windows/main.cpp
     src/server/windows/interception.h
   )

--- a/src/client/ClientState.cpp
+++ b/src/client/ClientState.cpp
@@ -5,6 +5,7 @@
 #include "common/output.h"
 #include <sstream>
 #include <utility>
+#include <WinSock2.h>
 
 namespace {
   KeySequence replace_logical_keys(KeySequence sequence) {
@@ -302,4 +303,15 @@ bool ClientState::on_inject_output_message(KeyEvent event) {
 bool ClientState::on_notify_message(const std::string& string) {
   notify("%s", string.c_str());
   return true;
+}
+
+void ClientState::update_cursor_visibility() {
+    CURSORINFO ci{};
+    ci.cbSize = sizeof(ci);
+
+    if (GetCursorInfo(&ci))
+    {
+        m_server.send_set_virtual_key_state(Key::CursorVisible,
+            (ci.flags & CURSOR_SHOWING) ? KeyState::Down : KeyState::Up);
+    }
 }

--- a/src/client/ClientState.cpp
+++ b/src/client/ClientState.cpp
@@ -5,7 +5,10 @@
 #include "common/output.h"
 #include <sstream>
 #include <utility>
+
+#if defined(_WIN32)
 #include <WinSock2.h>
+#endif
 
 namespace {
   KeySequence replace_logical_keys(KeySequence sequence) {
@@ -159,7 +162,9 @@ bool ClientState::send_config() {
     update_active_contexts(true);
     send_active_contexts();
   }
+#if defined(_WIN32)
   update_cursor_visibility();
+#endif
   return true;
 }
 
@@ -306,13 +311,13 @@ bool ClientState::on_notify_message(const std::string& string) {
   return true;
 }
 
+#if defined(_WIN32)
 void ClientState::update_cursor_visibility() {
-    CURSORINFO ci{};
-    ci.cbSize = sizeof(ci);
-
+    CURSORINFO ci = { sizeof(CURSORINFO) };
     if (GetCursorInfo(&ci))
     {
         m_server.send_set_virtual_key_state(Key::CursorVisible,
             (ci.flags & CURSOR_SHOWING) ? KeyState::Down : KeyState::Up);
     }
 }
+#endif

--- a/src/client/ClientState.cpp
+++ b/src/client/ClientState.cpp
@@ -159,6 +159,7 @@ bool ClientState::send_config() {
     update_active_contexts(true);
     send_active_contexts();
   }
+  update_cursor_visibility();
   return true;
 }
 

--- a/src/client/ClientState.h
+++ b/src/client/ClientState.h
@@ -29,6 +29,7 @@ public:
   std::optional<Socket> accept_control_connection();
   void read_control_messages();
   void request_next_key_info();
+  void update_cursor_visibility();
 
 protected:
   // server messages

--- a/src/client/windows/main.cpp
+++ b/src/client/windows/main.cpp
@@ -47,6 +47,7 @@ namespace {
   bool g_session_changed;
   HINSTANCE g_instance;
   HWND g_window;
+  HWINEVENTHOOK g_cursor_event;
   NOTIFYICONDATAW g_tray_icon;
 
   void show_notification(const char* text) {
@@ -195,6 +196,13 @@ namespace {
     TrackPopupMenu(popup_menu, 
       TPM_NOANIMATION | TPM_VCENTERALIGN,
       cursor_pos.x + 7, cursor_pos.y, 0, g_window, nullptr);
+  }
+
+  void CALLBACK cursor_event_proc(HWINEVENTHOOK hook, DWORD event,
+      HWND hwnd, LONG idObject, LONG idChild,
+      DWORD dwEventThread, DWORD dwmsEventTime) {
+      if (idObject == OBJID_CURSOR)
+          g_state.update_cursor_visibility();
   }
 
   LRESULT CALLBACK window_proc(HWND window, UINT message,
@@ -398,6 +406,12 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE, LPWSTR, int) {
   g_window = CreateWindowExW(0, window_class_name, NULL, 0,
     CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
     HWND_MESSAGE, NULL, NULL,  NULL);
+
+  g_cursor_event = SetWinEventHook(
+      EVENT_OBJECT_SHOW, EVENT_OBJECT_HIDE,
+      nullptr, cursor_event_proc,
+      0, 0,
+      WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
 
   if (!connect())
     return 1;

--- a/src/client/windows/main.cpp
+++ b/src/client/windows/main.cpp
@@ -210,6 +210,7 @@ namespace {
 
     switch(message) {
       case WM_DESTROY:
+        UnhookWinEvent(g_cursor_event);
         PostQuitMessage(0);
         return 0;
 

--- a/src/client/windows/main.cpp
+++ b/src/client/windows/main.cpp
@@ -286,8 +286,10 @@ namespace {
 
       case WM_TIMER: {
         if (wparam == TIMER_UPDATE_CONTEXT) {
-          if (g_state.update_active_contexts())
-            g_state.send_active_contexts();
+            if (g_state.update_active_contexts()) {
+                g_state.send_active_contexts();
+                g_state.update_cursor_visibility();
+            }
           validate_state();
         }
         else if (wparam == TIMER_UPDATE_CONFIG) {

--- a/src/client/windows/main.cpp
+++ b/src/client/windows/main.cpp
@@ -143,7 +143,7 @@ namespace {
         socket && WSAAsyncSelect(*socket, g_window,
           WM_APP_CONTROL_MESSAGE, (FD_READ | FD_CLOSE)) == 0)
       return true;
-    error("Accepting keymapperctl connection failed");
+    verbose("Accepting keymapperctl connection failed");
     return false;
   }
 

--- a/src/config/ParseKeySequence.cpp
+++ b/src/config/ParseKeySequence.cpp
@@ -337,6 +337,18 @@ void ParseKeySequence::check_ContextActive_usage() {
   }
 }
 
+void ParseKeySequence::check_CursorVisible_usage() {
+    const auto it = std::find_if(m_sequence.begin(), m_sequence.end(),
+      [](const KeyEvent& e) { return e.key == Key::CursorVisible; });
+    if (it != m_sequence.end()) {
+      if (!m_is_input)
+      throw ParseError("CursorVisible is only allowed in input");
+    if (m_sequence.size() == 2)
+      throw ParseError("CursorVisible cannot be used alone");
+    m_sequence.pop_back();
+  }
+}
+
 void ParseKeySequence::parse(It it, const It end) {
   auto is_no_might_match = false;
   auto output_on_release = false;
@@ -520,4 +532,5 @@ void ParseKeySequence::parse(It it, const It end) {
     throw ParseError("Virtual keys not allowed in no-might-match sequence");
 
   check_ContextActive_usage();
+  check_CursorVisible_usage();
 }

--- a/src/config/ParseKeySequence.h
+++ b/src/config/ParseKeySequence.h
@@ -72,6 +72,7 @@ private:
   void remove_all_from_end(KeyState state);
   void convert_final_not_to_up();
   void check_ContextActive_usage();
+  void check_CursorVisible_usage();
 
   std::string_view m_string;
   bool m_is_input{ };

--- a/src/config/get_key_name.cpp
+++ b/src/config/get_key_name.cpp
@@ -214,6 +214,7 @@ const char* get_key_name(Key key) {
 
     case Key::any:                return "Any";
     case Key::ContextActive:      return "ContextActive";
+    case Key::CursorVisible:      return "CursorVisible";
 
     case Key::none:
     case Key::timeout:

--- a/src/runtime/Key.h
+++ b/src/runtime/Key.h
@@ -477,6 +477,8 @@ enum class Key : uint16_t {
   first_auto_virtual = 0xF700, // 1024
   last_virtual       = 0xFAFF,
 
+  CursorVisible = 0xFB00,
+
   first_mouse_button = ButtonLeft,
   last_mouse_button  = ButtonForward,
 
@@ -509,15 +511,15 @@ constexpr Key get_logical_key(size_t index) {
 }
 
 constexpr bool is_virtual_key(Key key) {
-  return (key >= Key::first_virtual && key <= Key::last_virtual);
+    return ((key >= Key::first_virtual && key <= Key::last_virtual) || key == Key::CursorVisible);
 }
 
 constexpr int get_virtual_key_index(Key key) {
-  return (*key - *Key::first_virtual);
+    return (*key - *Key::first_virtual);
 }
 
 constexpr int get_virtual_key_count() {
-  return (*Key::last_virtual - *Key::first_virtual + 1);
+    return (*Key::last_virtual - *Key::first_virtual + 2); // + 2 to include CursorVisible
 }
 
 constexpr Key get_virtual_key(int index) {

--- a/src/server/ServerState.cpp
+++ b/src/server/ServerState.cpp
@@ -304,13 +304,6 @@ bool is_control_up(const KeyEvent& event) {
           event.key == Key::ControlRight));
 }
 
-bool ServerState::send_buffer_has_mouse_events() const {
-  return std::any_of(m_send_buffer.begin(), m_send_buffer.end(),
-    [](const KeyEvent& event) {
-      return is_mouse_button(event.key) || is_mouse_wheel(event.key);
-    });
-}
-
 bool ServerState::flush_send_buffer() {
   if (m_sending_key)
     return true;

--- a/src/server/ServerState.h
+++ b/src/server/ServerState.h
@@ -20,7 +20,6 @@ public:
   void set_device_descs(std::vector<DeviceDesc> device_descs);
   bool should_exit() const;
   bool translate_input(KeyEvent input, int device_index);
-  bool send_buffer_has_mouse_events() const;
   bool flush_send_buffer();
   bool sending_key() const { return m_sending_key; }
   const std::vector<StagePtr>& stages() const { return m_stage->stages(); }

--- a/src/server/windows/HookThread.cpp
+++ b/src/server/windows/HookThread.cpp
@@ -1,0 +1,141 @@
+
+#include "HookThread.h"
+#include "common/output.h"
+#include <thread>
+#include <future>
+#include <mutex>
+#include <utility>
+
+namespace {
+  constexpr UINT WM_APP_CONFIGURE_HOOKS = WM_APP + 0;
+
+  KeyboardHookCallback g_keyboard_hook_callback;
+  MouseHookCallback g_mouse_hook_callback;
+  HHOOK g_keyboard_hook;
+  HHOOK g_mouse_hook;
+  std::mutex g_hook_thread_mutex;
+  std::thread g_hook_thread;
+  DWORD g_hook_thread_id;
+
+  struct HookConfig {
+    HINSTANCE instance;
+    KeyboardHookCallback keyboard_callback;
+    MouseHookCallback mouse_callback;
+    std::promise<void> completed;
+  };
+
+  LRESULT CALLBACK keyboard_hook_proc(int code, WPARAM wparam, LPARAM lparam) {
+    if (code == HC_ACTION) {
+      const auto& kbd = *reinterpret_cast<const KBDLLHOOKSTRUCT*>(lparam);
+      if (g_keyboard_hook_callback && g_keyboard_hook_callback(wparam, kbd))
+        return 1;
+    }
+    return CallNextHookEx(g_keyboard_hook, code, wparam, lparam);
+  }
+
+  LRESULT CALLBACK mouse_hook_proc(int code, WPARAM wparam, LPARAM lparam) {
+    if (code == HC_ACTION) {
+      const auto& ms = *reinterpret_cast<const MSLLHOOKSTRUCT*>(lparam);
+      if (g_mouse_hook_callback && g_mouse_hook_callback(wparam, ms))
+        return 1;
+    }
+    return CallNextHookEx(g_mouse_hook, code, wparam, lparam);
+  }
+
+  void unhook_devices_on_hook_thread() {
+    if (g_keyboard_hook)
+      UnhookWindowsHookEx(g_keyboard_hook);
+    g_keyboard_hook = nullptr;
+    g_keyboard_hook_callback = nullptr;
+
+    if (g_mouse_hook)
+      UnhookWindowsHookEx(g_mouse_hook);
+    g_mouse_hook = nullptr;
+    g_mouse_hook_callback = nullptr;
+  }
+
+  void hook_devices_on_hook_thread(const HookConfig& config) {
+    const auto keyboard_was_hooked = (g_keyboard_hook_callback != nullptr);
+    const auto mouse_was_hooked = (g_mouse_hook_callback != nullptr);
+
+    unhook_devices_on_hook_thread();
+
+    g_keyboard_hook_callback = config.keyboard_callback;
+    if (g_keyboard_hook_callback)
+      g_keyboard_hook = SetWindowsHookExW(
+        WH_KEYBOARD_LL, keyboard_hook_proc, config.instance, 0);
+
+    g_mouse_hook_callback = config.mouse_callback;
+    if (g_mouse_hook_callback)
+      g_mouse_hook = SetWindowsHookExW(
+        WH_MOUSE_LL, mouse_hook_proc, config.instance, 0);
+
+    const auto keyboard_is_hooked = (g_keyboard_hook != nullptr);
+    const auto mouse_is_hooked = (g_mouse_hook != nullptr);
+    if (keyboard_is_hooked != keyboard_was_hooked)
+      verbose(keyboard_is_hooked ? "Hooked keyboard" : "Unhooked keyboard");
+    if (mouse_is_hooked != mouse_was_hooked)
+      verbose(mouse_is_hooked ? "Hooked mouse" : "Unhooked mouse");
+  }
+
+  void hook_thread_main(std::promise<void> ready) {
+    g_hook_thread_id = GetCurrentThreadId();
+
+    // create message queue
+    auto message = MSG{ };
+    PeekMessageW(&message, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+    ready.set_value();
+
+    while (GetMessageW(&message, nullptr, 0, 0) > 0)
+      if (message.message == WM_APP_CONFIGURE_HOOKS) {
+        auto& config = *reinterpret_cast<HookConfig*>(message.lParam);
+        hook_devices_on_hook_thread(config);
+        config.completed.set_value();
+      }
+
+    unhook_devices_on_hook_thread();
+  }
+
+  void start_hook_thread() {
+    if (g_hook_thread.joinable())
+      return;
+
+    auto ready = std::promise<void>();
+    auto ready_future = ready.get_future();
+    g_hook_thread = std::thread(hook_thread_main, std::move(ready));
+    ready_future.get();
+  }
+
+  void configure_devices(HookConfig config) {
+    auto completed = config.completed.get_future();
+    if (!PostThreadMessageW(g_hook_thread_id, WM_APP_CONFIGURE_HOOKS, 0,
+        reinterpret_cast<LPARAM>(&config)))
+      return;
+
+    completed.get();
+  }
+} // namespace
+
+void unhook_devices() {
+  const auto lock = std::lock_guard(g_hook_thread_mutex);
+  if (g_hook_thread.joinable())
+    configure_devices({ });
+}
+
+void hook_devices(HINSTANCE instance,
+    KeyboardHookCallback keyboard_hook_callback,
+    MouseHookCallback mouse_hook_callback) {
+  const auto lock = std::lock_guard(g_hook_thread_mutex);
+  start_hook_thread();
+  configure_devices({ instance, keyboard_hook_callback, mouse_hook_callback });
+}
+
+void shutdown_hook_thread() {
+  const auto lock = std::lock_guard(g_hook_thread_mutex);
+  if (!g_hook_thread.joinable())
+    return;
+
+  PostThreadMessageW(g_hook_thread_id, WM_QUIT, 0, 0);
+  g_hook_thread.join();
+  g_hook_thread_id = 0;
+}

--- a/src/server/windows/HookThread.h
+++ b/src/server/windows/HookThread.h
@@ -1,0 +1,11 @@
+
+#include "common/windows/win.h"
+
+using KeyboardHookCallback = bool(*)(WPARAM, const KBDLLHOOKSTRUCT& kbd);
+using MouseHookCallback = bool(*)(WPARAM, const MSLLHOOKSTRUCT& ms);
+
+void hook_devices(HINSTANCE instance,
+  KeyboardHookCallback keyboard_hook_callback,
+  MouseHookCallback mouse_hook_callback);
+void unhook_devices();
+void shutdown_hook_thread();

--- a/src/server/windows/main.cpp
+++ b/src/server/windows/main.cpp
@@ -4,6 +4,7 @@
 #include "runtime/Timeout.h"
 #include "common/windows/LimitSingleInstance.h"
 #include "common/output.h"
+#include "HookThread.h"
 #include "Devices.h"
 #include <WinSock2.h>
 
@@ -39,8 +40,6 @@ namespace {
 
   HINSTANCE g_instance;
   HWND g_window;
-  HHOOK g_keyboard_hook;
-  HHOOK g_mouse_hook;
   std::vector<Key> g_buttons_down;
   Devices g_devices;
   ServerStateImpl g_state;
@@ -284,22 +283,19 @@ namespace {
     return g_state.translate_input(input, keyboard_device_index);
   }
 
-  LRESULT CALLBACK keyboard_hook_proc(int code, WPARAM wparam, LPARAM lparam) {
-    if (code == HC_ACTION) {
-      const auto& kbd = *reinterpret_cast<const KBDLLHOOKSTRUCT*>(lparam);
-      if (translate_keyboard_input(wparam, kbd)) {
-        // never send mouse events directly from the keyboard hook proc since it can block
-        if (g_state.send_buffer_has_mouse_events()) {
-          g_state.schedule_flush();
-        }
-        else {
-          if (!g_state.flush_scheduled_at())
-            g_state.flush_send_buffer();
-        }
-        return -1;
+  bool CALLBACK keyboard_hook_callback(WPARAM wparam, const KBDLLHOOKSTRUCT& kbd) {
+    if (translate_keyboard_input(wparam, kbd)) {
+      // never send mouse events directly from the keyboard hook proc since it can block
+      if (g_state.send_buffer_has_mouse_events()) {
+        g_state.schedule_flush();
       }
+      else {
+        if (!g_state.flush_scheduled_at())
+          g_state.flush_send_buffer();
+      }
+      return true;
     }
-    return CallNextHookEx(g_keyboard_hook, code, wparam, lparam);
+    return false;
   }
 
   std::optional<KeyEvent> get_button_event(WPARAM wparam, const MSLLHOOKSTRUCT& ms) {
@@ -349,30 +345,16 @@ namespace {
     return prevent_button_repeat(*input);
   }
 
-  LRESULT CALLBACK mouse_hook_proc(int code, WPARAM wparam, LPARAM lparam) {
-    if (code == HC_ACTION) {
-      const auto& ms = *reinterpret_cast<const MSLLHOOKSTRUCT*>(lparam);
-      if (translate_mouse_input(wparam, ms)) {
-        g_state.schedule_flush();
-        return -1;
-      }
+  bool mouse_hook_callback(WPARAM wparam, const MSLLHOOKSTRUCT& ms) {
+    if (translate_mouse_input(wparam, ms)) {
+      g_state.schedule_flush();
+      return true;
     }
-    return CallNextHookEx(g_mouse_hook, code, wparam, lparam);
-  }
-
-  void unhook_devices() {
-    if (auto hook = std::exchange(g_keyboard_hook, nullptr))
-      UnhookWindowsHookEx(hook);
-    if (auto hook = std::exchange(g_mouse_hook, nullptr))
-      UnhookWindowsHookEx(hook);
+    return false;
   }
 
   void hook_devices() {
-    const auto keyboard_was_hooked = (g_keyboard_hook != nullptr);
-    const auto mouse_was_hooked = (g_mouse_hook != nullptr);
 
-    unhook_devices();
-    
     if (g_devices.initialized())
       return;
 
@@ -390,24 +372,9 @@ namespace {
     hook_mouse = evaluate_grab_filters(g_devices.grab_filters(), 
       "mouse", "mouse", hook_mouse);
     
-    if (hook_keyboard) {
-      g_keyboard_hook = SetWindowsHookExW(
-        WH_KEYBOARD_LL, &keyboard_hook_proc, g_instance, 0);
-      if (!g_keyboard_hook)
-        error("Hooking keyboard failed");
-    }
-    
-    if (hook_mouse) {
-      g_mouse_hook = SetWindowsHookExW(
-        WH_MOUSE_LL, &mouse_hook_proc, g_instance, 0);
-      if (!g_mouse_hook)
-        error("Hooking mouse failed");
-    }
-
-    if (hook_keyboard != keyboard_was_hooked)
-      verbose(hook_keyboard ? "Hooked keyboard" : "Unhooked keyboard");
-    if (hook_mouse != mouse_was_hooked)
-      verbose(hook_mouse ? "Hooked mouse" : "Unhooked mouse");
+    hook_devices(g_instance,
+      hook_keyboard ? &keyboard_hook_callback : nullptr,
+      hook_mouse ? &mouse_hook_callback : nullptr);
   }
 
   bool is_unconditionally_forwarding() {
@@ -599,5 +566,6 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE, LPWSTR, int) {
     DispatchMessageW(&message);
   }
   verbose("Exiting");
+  shutdown_hook_thread();
   return 0;
 }

--- a/src/server/windows/main.cpp
+++ b/src/server/windows/main.cpp
@@ -7,6 +7,7 @@
 #include "HookThread.h"
 #include "Devices.h"
 #include <WinSock2.h>
+#include <mutex>
 
 // enable visual styles for message boxes
 #pragma comment(linker,"\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
@@ -27,9 +28,6 @@ namespace {
     std::string get_devices_error_message() override;
   };
   
-  // Calling SendInput directly from mouse hook proc seems to trigger a
-  // timeout, therefore it is called after returning from the hook proc. 
-  // But for keyboard input it is still more reliable to call it directly!
   const auto TIMER_FLUSH_SEND_BUFFER = 1;
   const auto TIMER_TIMEOUT = 2;
   const auto WM_APP_CLIENT_MESSAGE = WM_APP + 0;
@@ -44,6 +42,23 @@ namespace {
   Devices g_devices;
   ServerStateImpl g_state;
   std::vector<INPUT> g_input_buffer;
+  std::vector<INPUT> g_flush_input_buffer;
+  std::mutex g_hook_callback_mutex;
+
+  class unlock_guard {
+  public:
+    explicit unlock_guard(std::mutex& mutex)
+      : m_mutex(mutex) {
+      m_mutex.unlock();
+    }
+
+    ~unlock_guard() {
+      m_mutex.lock();
+    }
+
+  private:
+    std::mutex& m_mutex;
+  };
 
   KeyEvent get_key_event(WPARAM wparam, const KBDLLHOOKSTRUCT& kbd) {
     // ignore unknown events
@@ -199,35 +214,21 @@ namespace {
     return ++result;
   }
 
-  bool merge_wheel_event(INPUT& a, const INPUT& b) {
-    if (a.type == INPUT_MOUSE &&
-        b.type == INPUT_MOUSE &&
-        a.mi.dwFlags == b.mi.dwFlags) {
-      const auto value_a = static_cast<int>(a.mi.mouseData);
-      const auto value_b = static_cast<int>(b.mi.mouseData);
-      if (std::signbit(value_a) == std::signbit(value_b)) {
-        a.mi.mouseData = static_cast<DWORD>(value_a + value_b);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  void merge_wheel_events(std::vector<INPUT>& input) {
-    input.erase(unique_mutable(begin(input), end(input), 
-      &merge_wheel_event), end(input));
-  }
-
   bool ServerStateImpl::on_flushed_send_buffer() {
-    // merge wheel events, since sending many can lag severly
-    merge_wheel_events(g_input_buffer);
+    while (!g_input_buffer.empty()) {
+      std::swap(g_input_buffer, g_flush_input_buffer);
+      
+      // allow hook callbacks to run concurrently
+      // when they are called as a consequence of sending input
+      const auto unlock = unlock_guard(g_hook_callback_mutex);
 
-    // sending each input separately, since Windows starts beeping
-    // when sending multiple mouse click events at once
-    for (auto& input : g_input_buffer)
-      ::SendInput(1, &input, sizeof(input));
+      // sending each input separately, since Windows starts beeping
+      // when sending multiple mouse click events at once
+      for (auto& input : g_flush_input_buffer)
+        ::SendInput(1, &input, sizeof(INPUT));
 
-    g_input_buffer.clear();
+      g_flush_input_buffer.clear();
+    }
     return true;
   }
 
@@ -284,15 +285,9 @@ namespace {
   }
 
   bool CALLBACK keyboard_hook_callback(WPARAM wparam, const KBDLLHOOKSTRUCT& kbd) {
+    const auto lock = std::lock_guard(g_hook_callback_mutex);
     if (translate_keyboard_input(wparam, kbd)) {
-      // never send mouse events directly from the keyboard hook proc since it can block
-      if (g_state.send_buffer_has_mouse_events()) {
-        g_state.schedule_flush();
-      }
-      else {
-        if (!g_state.flush_scheduled_at())
-          g_state.flush_send_buffer();
-      }
+      g_state.schedule_flush();
       return true;
     }
     return false;
@@ -346,6 +341,7 @@ namespace {
   }
 
   bool mouse_hook_callback(WPARAM wparam, const MSLLHOOKSTRUCT& ms) {
+    const auto lock = std::lock_guard(g_hook_callback_mutex);
     if (translate_mouse_input(wparam, ms)) {
       g_state.schedule_flush();
       return true;
@@ -354,7 +350,6 @@ namespace {
   }
 
   void hook_devices() {
-
     if (g_devices.initialized())
       return;
 
@@ -372,6 +367,7 @@ namespace {
     hook_mouse = evaluate_grab_filters(g_devices.grab_filters(), 
       "mouse", "mouse", hook_mouse);
     
+    const auto unlock = unlock_guard(g_hook_callback_mutex);
     hook_devices(g_instance,
       hook_keyboard ? &keyboard_hook_callback : nullptr,
       hook_mouse ? &mouse_hook_callback : nullptr);
@@ -448,6 +444,9 @@ namespace {
 
   LRESULT CALLBACK window_proc(HWND window, UINT message,
       WPARAM wparam, LPARAM lparam) {
+
+    const auto lock = std::lock_guard(g_hook_callback_mutex);
+
     switch(message) {
       case WM_DESTROY:
         g_devices.shutdown();
@@ -466,6 +465,8 @@ namespace {
           verbose("Connection to keymapper lost");
           verbose("---------------");
           g_state.reset_configuration();
+
+          const auto unlock = unlock_guard(g_hook_callback_mutex);
           unhook_devices();
         }
         return 0;


### PR DESCRIPTION
New virtual key "**CursorVisible**" that changes depending on the mouse cursor visibility
It is pressed when the cursor is visible, and released when the cursor is hidden
This modifier can be useful in games where you need different mappings in menus (visible cursor) and in-game (hidden cursor)

Limitations:

- Only works on Windows
- Can only detect hardware cursor changes


It can be used as a modifier in context blocks or mappings

Example context blocks:
```
[path = "program.exe", modifier = "CursorVisible"]
# Mappings under this context block will only work while the cursor is visible
```

```
[path = "program.exe", modifier = "!CursorVisible"]
# Mappings under this context block will only work while the cursor is hidden
```


Example mappings:
```
CursorVisible{E} >> PageDown
CursorVisible D >> Space
(CursorVisible W) >> I
!CursorVisible A >> Left
```