### PR TITLE
fix: prevent IPC socket fd leak into child processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Prevent IPC socket fd leak into child processes spawned by `$(...)` config commands, which caused `Binding control port failed` errors after restart ([#388](https://github.com/houmain/keymapper/pull/388)).
+
 ## [Version 5.6.0] - 2026-06-14
 
 ### Added

--- a/src/common/Host.cpp
+++ b/src/common/Host.cpp
@@ -66,6 +66,15 @@ void make_non_blocking(Socket socket_fd) {
 
 #else // !defined(_WIN32)
 
+#include <features.h>
+// accept4() requires _GNU_SOURCE on glibc >= 2.10.
+// On musl it is available without any feature-test macro.
+#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 10)
+  #define HAVE_ACCEPT4 1
+  #ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+  #endif
+#endif
 #include <csignal>
 #include <unistd.h>
 #include <fcntl.h>
@@ -120,7 +129,7 @@ Host::~Host() {
 }
 
 bool Host::listen() {
-  m_listen_fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  m_listen_fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (m_listen_fd == invalid_socket)
     return false;
 
@@ -158,9 +167,16 @@ Connection Host::accept(std::optional<Duration> timeout) {
   if (!block_until_readable(m_listen_fd, timeout))
     return { };
 
+# if defined(HAVE_ACCEPT4)
+  auto socket_fd = ::accept4(m_listen_fd, nullptr, nullptr, SOCK_CLOEXEC);
+# else
   auto socket_fd = ::accept(m_listen_fd, nullptr, nullptr);
+# endif
   if (socket_fd == invalid_socket)
     return { };
+# if !defined(HAVE_ACCEPT4)
+  ::fcntl(socket_fd, F_SETFD, ::fcntl(socket_fd, F_GETFD) | FD_CLOEXEC);
+# endif
   make_blocking(socket_fd);
   auto connection = Connection(socket_fd);
 
@@ -190,7 +206,7 @@ Connection Host::connect(std::optional<Duration> timeout) {
   const auto retry_until_timepoint = (timeout ?
     std::make_optional(Clock::now() + *timeout) : std::nullopt);
 
-  auto socket_fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  auto socket_fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   for (;;) {
     if (socket_fd == invalid_socket)
       return { };
@@ -205,7 +221,7 @@ Connection Host::connect(std::optional<Duration> timeout) {
           !connection.read(&versions_match)) {
         // this fails regularly when reconnecting to a closing host
         connection.disconnect();
-        socket_fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+        socket_fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
         continue;
       }
       if (!versions_match)


### PR DESCRIPTION
## Problem

Keymapper creates an abstract Unix domain socket (`@keymapperctl`) for IPC between the client and daemon. This socket fd is inherited by child processes spawned via `$(...)` config commands (e.g. `kitty`, `tofi`, `swaymsg`).

These children keep the socket fd open and listening. When keymapper is restarted (e.g. by a service manager, or config reload), the new process cannot bind `@keymapperctl` because the leaked processes still hold it. This produces `Binding control port failed` errors and keybindings stop working until all the leaked processes are manually killed.

## Root Cause

All `socket()` calls in `Host.cpp` use plain `SOCK_STREAM` without `SOCK_CLOEXEC`, so the fd survives `exec()` into child processes.

## Fix

Add `SOCK_CLOEXEC` to all Unix socket calls in `Host.cpp`:

- `listen()`: `socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0)`
- `accept()`: use `accept4()` with `SOCK_CLOEXEC` when available (detected via `__GLIBC_PREREQ(2,10)` for glibc; musl provides it without any feature-test macro), fall back to `accept()` + `fcntl(FD_CLOEXEC)` otherwise
- `connect()`: `SOCK_CLOEXEC` on both initial and retry `socket()` calls

## Testing

- Verified `accept4` and `SOCK_CLOEXEC` present in the built binary via `objdump` / `nm -D`
- Confirmed spawned terminals (kitty) no longer appear in `ss -xlp` output for `@keymapperctl` after keymapper restart
- Service restarts cleanly without `Binding control port failed`
- Tested on Linux x86_64 with keymapper 5.6.0

## Compatibility

- `accept4` availability is detected via `__GLIBC_PREREQ(2,10)` for glibc. On musl it is available without `_GNU_SOURCE`. Other platforms (macOS, BSD) fall back to `accept()` + `fcntl(FD_CLOEXEC)`.
- No behaviour change for existing users — `CLOEXEC` only affects `exec()`, not normal fd lifetime.